### PR TITLE
Extend metadata append function

### DIFF
--- a/sparc_me/core/dataset.py
+++ b/sparc_me/core/dataset.py
@@ -438,7 +438,7 @@ class Dataset(object):
             msg = "row_name should be string."
             raise ValueError(msg)
 
-        # Assumes that all excel files first column is contains the unique value field
+        # Assumes that all excel files first column contains the unique value field
         matching_indices = metadata.index[metadata[metadata.columns[0]]==row_name].tolist()
 
         if not matching_indices:

--- a/sparc_me/core/dataset.py
+++ b/sparc_me/core/dataset.py
@@ -439,6 +439,8 @@ class Dataset(object):
             raise ValueError(msg)
 
         # Assumes that all excel files first column contains the unique value field
+        # TODO: In version 1, the unique column is not the column 0. Hence, unique column must be specified. 
+        # This method need to be fixed to accomadate this 
         matching_indices = metadata.index[metadata[metadata.columns[0]]==row_name].tolist()
 
         if not matching_indices:
@@ -481,7 +483,7 @@ class Dataset(object):
                 raise ValueError(error_msg)
             
             try:
-                row_index = check_row_exist(metadata, row[unique_column])
+                row_index = check_row_exist(metadata, unique_column, unique_value=row[unique_column])
             except ValueError:
                 error_msg = "Row values provided does not contain a unique identifier"
                 raise ValueError(error_msg)

--- a/sparc_me/core/dataset.py
+++ b/sparc_me/core/dataset.py
@@ -467,8 +467,10 @@ class Dataset(object):
             msg = "Dataset not defined. Please load the dataset in advance."
             raise ValueError(msg)
 
+        row_df = pd.DataFrame([row])
+
         metadata = self._dataset.get(category).get("metadata")
-        metadata = metadata.append(row, ignore_index=True)
+        metadata = pd.concat([metadata, row_df], axis=0, ignore_index=True)     #If new header comes, it will be added as a new column with its value
 
         self._dataset[category]["metadata"] = metadata
 

--- a/sparc_me/core/utils.py
+++ b/sparc_me/core/utils.py
@@ -39,7 +39,7 @@ def add_data(source_path, destination_path, copy=True, overwrite=False):
                 shutil.move(file_path, os.path.join(destination_path, fname))
 
 
-def check_row_exist(dataframe, unique_value):
+def check_row_exist(dataframe, unique_column, unique_value):
     """Check if a row exist with given unique value
 
     :param dataframe: metadata dataframe that must be checked
@@ -50,7 +50,7 @@ def check_row_exist(dataframe, unique_value):
     :rtype: int
     :raises ValueError: if more than one row can be identified with given unique value
     """
-    row_index = dataframe.index[dataframe[dataframe.columns[0]]==unique_value].tolist()
+    row_index = dataframe.index[dataframe[unique_column]==unique_value].tolist()
     if not row_index:
         row_index = -1
     elif len(row_index)>1:

--- a/sparc_me/core/utils.py
+++ b/sparc_me/core/utils.py
@@ -37,3 +37,25 @@ def add_data(source_path, destination_path, copy=True, overwrite=False):
             else:
                 # Move data
                 shutil.move(file_path, os.path.join(destination_path, fname))
+
+
+def check_row_exist(dataframe, unique_value):
+    """Check if a row exist with given unique value
+
+    :param dataframe: metadata dataframe that must be checked
+    :type dataframe: Pandas DataFrame
+    :param unique_value: value that can be used to uniquely identifies a row
+    :type unique_value: string
+    :return: row index of the row identified with the unique value, or -1 if there is no row corresponding to the unique value
+    :rtype: int
+    :raises ValueError: if more than one row can be identified with given unique value
+    """
+    row_index = dataframe.index[dataframe[dataframe.columns[0]]==unique_value].tolist()
+    if not row_index:
+        row_index = -1
+    elif len(row_index)>1:
+        error_msg = "More than one row can be identified with given unique value"
+        raise ValueError(error_msg)
+    else:
+        row_index = row_index[0]
+    return row_index


### PR DESCRIPTION
## Description:
- Replaced `Pandas.DataFrame.append()` method which will be deprecated in future, with `Pandas.DataFrame.concat()` 
- Extend the metadata append function to check if the row already exists, before adding a row. If it exists, the row will be updated with any new metadata. `check_exist` is currently optional, meaning that, it is possible to append rows with duplicated unique identifiers. (Ex: If a user set `check_exist` to False and add rows with the same `subject_id` to the `subjects.xlsx` file twice, there will be two rows with the same `subject_id`.) I implemented the functionality this way considering two aspects 
    1. Since the method is generic, for some metadata files, this might be acceptable behavior.
    2. Considering the behavior of the append method prior to the modifications I did. i.e. before I modified the append method, it was adding the row disregarding whether it exists or not. 

However, we can discuss and agree upon a final approach.

## Related issue(s):
#30 
#32 

## Test Environment:
Ubuntu 20.04
Python 3.9
