### PR TITLE
Ability to download entire dataset (>5GB) using multi-threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 .DS_Store
+examples/dataset
 # C extensions
 *.so
 .env

--- a/examples/example_for_download_whole_dataset.py
+++ b/examples/example_for_download_whole_dataset.py
@@ -7,4 +7,4 @@ if __name__ == '__main__':
     api_tools.download_dataset(156)
     end = time.time()
 
-    print("single thread to download dataset 156 cost:", end - start, "seconds!")
+    print("multi-threads to download dataset 156 cost:", end - start, "seconds!")

--- a/examples/example_for_download_whole_dataset.py
+++ b/examples/example_for_download_whole_dataset.py
@@ -4,7 +4,7 @@ import time
 if __name__ == '__main__':
     api_tools = Dataset_Api()
     start = time.time()
-    api_tools.download_dataset(156)
+    api_tools.download_dataset(273, 3)
     end = time.time()
 
     print("multi-threads to download dataset 156 cost:", end - start, "seconds!")

--- a/examples/example_for_download_whole_dataset.py
+++ b/examples/example_for_download_whole_dataset.py
@@ -1,0 +1,10 @@
+from sparc_me import Dataset_Api
+import time
+
+if __name__ == '__main__':
+    api_tools = Dataset_Api()
+    start = time.time()
+    api_tools.download_dataset(156)
+    end = time.time()
+
+    print("single thread to download dataset 156 cost:", end - start, "seconds!")

--- a/examples/example_for_download_whole_dataset.py
+++ b/examples/example_for_download_whole_dataset.py
@@ -4,7 +4,15 @@ import time
 if __name__ == '__main__':
     api_tools = Dataset_Api()
     start = time.time()
-    api_tools.download_dataset(273, 3)
+    # api_tools.download_dataset(156, 1)
+    # api_tools.download_dataset(156, -1)
+    # api_tools.download_dataset(156, 11)
+    # api_tools.download_dataset(156, "1")
+    # api_tools.download_dataset(156, "11")
+    # api_tools.download_dataset("156", "11")
+    # api_tools.download_dataset(156, "-11")
+    api_tools.download_dataset(156)
+
     end = time.time()
 
     print("multi-threads to download dataset 156 cost:", end - start, "seconds!")

--- a/sparc_me/core/api_tools.py
+++ b/sparc_me/core/api_tools.py
@@ -268,8 +268,14 @@ class Dataset_Api:
             return
         if version_id is None:
             version_id = latest_version_id
-        if version_id >= int(latest_version_id):
-            version_id = int(latest_version_id)
+        version_id = str(version_id)
+        if int(version_id) > int(latest_version_id):
+            version_id = latest_version_id
+            print(
+                "Your input version ID is greater that the one exist in SPARC dataset, Now will download the latest version in SPARC for you!")
+        if int(version_id) < 1:
+            version_id = "1"
+            print("Invalid version id, Now will download the first version of the dataset for you!")
 
         paths = self.get_all_files_path(dataset_id, version_id)
         self.mkdir(paths)


### PR DESCRIPTION
## Description:
add download a whole dataset, and add an example for this in the examples folder. `example_for_download_whole_dataset.py`.

Initially using a single thread to complete this task will cost several minutes.
Now, I redesign a multi-thread architecture to achieve this task only cost almost 26 seconds!


## Related issue(s):
#37 

## Test Environment:
Specify the testing enviroment. Mac OS python 3.9
